### PR TITLE
Fix ModuleNotFoundError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ tensorboard==2.3.0
 torch==1.6.0
 torchvision==0.7.0
 Unidecode==1.1.1
+mxnet==1.9.1
+gluonnlp==0.10.0
+transformers==4.18.0


### PR DESCRIPTION
ModuleNotFoundError: No module named 'gluonnlp'

pip install --upgrade mxnet>=1.6.0
pip install gluonnlp
pip install transformers
pip install transformers --upgrade